### PR TITLE
#62: Fix credential data not showing in Vault

### DIFF
--- a/docs/tutorial/verifiable_credentials.xxx
+++ b/docs/tutorial/verifiable_credentials.xxx
@@ -53,6 +53,8 @@ VeridaVCExample = () => {
       result: "Negative",
       schema:
         "https://common.schemas.verida.io/health/pathology/tests/covid19/pcr/v0.1.0/schema.json",
+      name: "Covid-19 Test Credential",
+      summary: "Credential issued at " + new Date().toDateString()
     }
 
 
@@ -86,7 +88,9 @@ VeridaVCExample = () => {
     await messaging.send(
       veridaContext.account.accountDid,
       messageType,
-      credential,
+      {
+        data: [credential]
+      },
       subject,
       config
     )


### PR DESCRIPTION
- Fix incorrect syntax in `messaging.send()`.
- Add missing fields for displaying in Vault data item.

![IMG_1929](https://user-images.githubusercontent.com/12524553/161965122-a510f4d1-cfef-48ba-8923-84f44aef994c.PNG)

